### PR TITLE
Add name property for basename sans extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metalsmith Paths [![version][npm-version]][npm-url] [![License][npm-license]][license-url]
 
-A Metalsmith plugin that adds file path values (`dirname`, `extname`, `basename`, `path`) to metadata.
+A Metalsmith plugin that adds file path values (`dirname`, `extname`, `basename`, `path`, `name`) to metadata.
 
 [![Build Status][travis-image]][travis-url]
 [![Downloads][npm-downloads]][npm-url]

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,11 @@ module.exports = function plugin (options) {
       debug('process file: %s', file)
 
       // add file path info
+      var extname = path.extname(file)
       files[file].dirname = path.dirname(file)
-      files[file].extname = path.extname(file)
+      files[file].extname = extname
       files[file].basename = path.basename(file)
+      files[file].name = path.basename(file, extname)
 
       // add path meta for use in links in templates
       files[file].path = '/' + path.dirname(file) + '/'

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ describe('Metalsmith Paths', function () {
       files['path/to/file.ext'].should.have.property('dirname').and.equal('path/to')
       files['path/to/file.ext'].should.have.property('extname').and.equal('.ext')
       files['path/to/file.ext'].should.have.property('basename').and.equal('file.ext')
+      files['path/to/file.ext'].should.have.property('name').and.equal('file')
       files['path/to/file.ext'].should.have.property('path').and.equal('/path/to/')
 
       done()


### PR DESCRIPTION
Adds a `name` property to the file metadata that does not include the extension. This is helpful when working with the [metalsmith-permalinks](https://github.com/segmentio/metalsmith-permalinks) plugin to build static websites.

A common file path for a blog post on a static website is something like `/blog/blog-post-title/index.html`. You can access this new `name` property in the template of your blog post loop to link to the blog post if you are only displaying a summary of the blog post in your loop:

```
{{#each collections.posts}}
  <div style="margin-bottom: 30px;">
    <h2><a href="blog/{{this.name}}/index.html">{{{this.title}}}</a></h2>
    <p>{{this.summary}}</p>
  </div>
{{/each}}
```

Thanks for reviewing!
