### PR TITLE
updated href attribute to use a directory index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,35 @@ You can also use the plugin with the Metalsmith CLI by adding a key to your `met
 
 ## Options
 
-| name       | description                        | default |
-| ---------- | ---------------------------------- | ------- |
-| `property` | property to store the path data to | `path`  |
+| name             | description                        | default   |
+| ---------------- | ---------------------------------- | --------- |
+| `property`       | property to store the path data to | `path`    |
+| `directoryIndex` | remove the filename if it matches  | disabled  |
 
+### directoryIndex
+
+Removes the filename from the `href` attribute if it matches the value of 
+`directoryIndex`. Default: disabled. For example, the following configuration:
+
+```json
+{
+  "plugins": {
+    "metalsmith-paths": {
+      "property": "path",
+      "directoryIndex": "index.html"
+    }
+  }
+}
+```
+
+Would produce the following filenames:
+
+| Filename                      | path.href                     |
+| ----------------------------- | ----------------------------- |
+| /index.html                   | /                             |
+| /portfolio/index.html         | /portfolio/                   |
+| /portfolio/project1.html      | /portfolio/project1.html      |
+| /portfolio/project2.html      | /portfolio/project2.html      |
 
 ## Support
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var path = require('path')
 module.exports = function plugin (options) {
   var opts = options || {}
   var prop = opts.property || 'path'
+  var directoryIndex = opts.directoryIndex || false
 
   return function (files, metalsmith, done) {
     setImmediate(done)
@@ -34,13 +35,24 @@ module.exports = function plugin (options) {
         }
       }
 
-      // default to root
-      files[file][prop].href = '/'
-
-      // add path meta for use in links in templates
-      if (files[file][prop].dir !== '') {
-        files[file][prop].href = '/' + files[file][prop].dir + '/'
+      // In some versions of node/path, 'dir' at root may be either '.' or empty
+      // Normalize this property to be empty
+      if (files[file][prop].dir === '.') {
+        files[file][prop].dir = ''
       }
+
+      // generate href
+      var href = '/'
+
+      if (files[file][prop].dir && files[file][prop].dir !== '.') {
+        href += files[file][prop].dir + '/'
+      }
+
+      if (!directoryIndex || path.basename(file) !== directoryIndex) {
+        href += path.basename(file)
+      }
+
+      files[file][prop].href = href
     })
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ describe('Metalsmith Paths', function () {
       files['path/to/file.ext'].path.should.have.property('dir').and.equal('path/to')
       files['path/to/file.ext'].path.should.have.property('ext').and.equal('.ext')
       files['path/to/file.ext'].path.should.have.property('name').and.equal('file')
-      files['path/to/file.ext'].path.should.have.property('href').and.equal('/path/to/')
+      files['path/to/file.ext'].path.should.have.property('href').and.equal('/path/to/file.ext')
 
       done()
     })
@@ -43,7 +43,73 @@ describe('Metalsmith Paths', function () {
       files['path/to/file.ext'].foo.should.have.property('dir').and.equal('path/to')
       files['path/to/file.ext'].foo.should.have.property('ext').and.equal('.ext')
       files['path/to/file.ext'].foo.should.have.property('name').and.equal('file')
-      files['path/to/file.ext'].foo.should.have.property('href').and.equal('/path/to/')
+      files['path/to/file.ext'].foo.should.have.property('href').and.equal('/path/to/file.ext')
+
+      done()
+    })
+  })
+
+  it('should respect directory indexes', function (done) {
+    plugin.should.be.a.Function
+
+    var files = {
+      'path/to/index.html': {},
+      'path/to/file.ext': {}
+    }
+
+    plugin({
+      directoryIndex: 'index.html'
+    })(files, null, function () {
+      files['path/to/index.html'].should.have.property('path').and.be.an.Object
+      files['path/to/index.html'].path.should.have.property('base').and.equal('index.html')
+      files['path/to/index.html'].path.should.have.property('dir').and.equal('path/to')
+      files['path/to/index.html'].path.should.have.property('ext').and.equal('.html')
+      files['path/to/index.html'].path.should.have.property('name').and.equal('index')
+      files['path/to/index.html'].path.should.have.property('href').and.equal('/path/to/')
+
+      files['path/to/file.ext'].should.have.property('path').and.be.an.Object
+      files['path/to/file.ext'].path.should.have.property('base').and.equal('file.ext')
+      files['path/to/file.ext'].path.should.have.property('dir').and.equal('path/to')
+      files['path/to/file.ext'].path.should.have.property('ext').and.equal('.ext')
+      files['path/to/file.ext'].path.should.have.property('name').and.equal('file')
+      files['path/to/file.ext'].path.should.have.property('href').and.equal('/path/to/file.ext')
+
+      done()
+    })
+  })
+
+  it('should return slash on directoryIndex root', function (done) {
+    plugin.should.be.a.Function
+
+    var files = {
+      'index.html': {},
+      'directory/index.html': {},
+      'directory/file.html': {}
+    }
+
+    plugin({
+      directoryIndex: 'index.html'
+    })(files, null, function () {
+      files['index.html'].should.have.property('path').and.be.an.Object
+      files['index.html'].path.should.have.property('base').and.equal('index.html')
+      files['index.html'].path.should.have.property('dir').and.equal('')
+      files['index.html'].path.should.have.property('ext').and.equal('.html')
+      files['index.html'].path.should.have.property('name').and.equal('index')
+      files['index.html'].path.should.have.property('href').and.equal('/')
+
+      files['directory/index.html'].should.have.property('path').and.be.an.Object
+      files['directory/index.html'].path.should.have.property('base').and.equal('index.html')
+      files['directory/index.html'].path.should.have.property('dir').and.equal('directory')
+      files['directory/index.html'].path.should.have.property('ext').and.equal('.html')
+      files['directory/index.html'].path.should.have.property('name').and.equal('index')
+      files['directory/index.html'].path.should.have.property('href').and.equal('/directory/')
+
+      files['directory/file.html'].should.have.property('path').and.be.an.Object
+      files['directory/file.html'].path.should.have.property('base').and.equal('file.html')
+      files['directory/file.html'].path.should.have.property('dir').and.equal('directory')
+      files['directory/file.html'].path.should.have.property('ext').and.equal('.html')
+      files['directory/file.html'].path.should.have.property('name').and.equal('file')
+      files['directory/file.html'].path.should.have.property('href').and.equal('/directory/file.html')
 
       done()
     })


### PR DESCRIPTION
At the moment, there may be multiple files inside a directory and the `href` attribute will remove the name of the filename. This option automatically puts the filename there if it is not the directory index filename.
