### PR TITLE
Fix path separator issues on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,12 @@ var path = require('path')
  * @return {Function}
  */
 
+function normalizePath (pathName) {
+  var normalized = pathName.split(path.sep).join('/')
+  debug(`normalized ${pathName} to ${normalized}`)
+  return normalized
+}
+
 module.exports = function plugin (options) {
   var opts = options || {}
   var prop = opts.property || 'path'
@@ -23,13 +29,14 @@ module.exports = function plugin (options) {
         debug('[node >= 0.11.15] using path.parse')
 
         files[file][prop] = path.parse(file)
+        files[file][prop].dir = normalizePath(files[file][prop].dir)
       } else {
         // add file path info
         var extname = path.extname(file)
 
         files[file][prop] = {
           base: path.basename(file),
-          dir: path.dirname(file),
+          dir: normalizePath(path.dirname(file)),
           ext: extname,
           name: path.basename(file, extname)
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ var path = require('path')
 
 function normalizePath (pathName) {
   var normalized = pathName.split(path.sep).join('/')
-  debug(`normalized ${pathName} to ${normalized}`)
+  debug('normalized' + pathName + ' to ' + normalized)
   return normalized
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -3,25 +3,29 @@
 'use strict'
 
 var plugin = require('..')
+var path = require('path')
 
 require('should')
 
 describe('Metalsmith Paths', function () {
+  // Use a real file.  Making it up masks compatibility issues, e.g. on Windows it will have
+  // back-slashes instead of forward-slashes but the output for href should always be forward-slashes
+  var absoluteFilePath = path.resolve('./path/to/file.ext')
+  var currentDir = path.resolve('.')
+  var relativeFilePath = path.relative(currentDir, absoluteFilePath)
+  var files = {}
+  files[relativeFilePath] = {}
+
   it('should be a plugin', function (done) {
     plugin.should.be.a.Function
 
-    var files = {
-      'path/to/file.ext': {}
-    }
-
     plugin()(files, null, function () {
-      files['path/to/file.ext'].should.have.property('path').and.be.an.Object
-
-      files['path/to/file.ext'].path.should.have.property('base').and.equal('file.ext')
-      files['path/to/file.ext'].path.should.have.property('dir').and.equal('path/to')
-      files['path/to/file.ext'].path.should.have.property('ext').and.equal('.ext')
-      files['path/to/file.ext'].path.should.have.property('name').and.equal('file')
-      files['path/to/file.ext'].path.should.have.property('href').and.equal('/path/to/file.ext')
+      files[relativeFilePath].should.have.property('path').and.be.an.Object
+      files[relativeFilePath].path.should.have.property('base').and.equal('file.ext')
+      files[relativeFilePath].path.should.have.property('dir').and.equal('path/to')
+      files[relativeFilePath].path.should.have.property('ext').and.equal('.ext')
+      files[relativeFilePath].path.should.have.property('name').and.equal('file')
+      files[relativeFilePath].path.should.have.property('href').and.equal('/path/to/file.ext')
 
       done()
     })
@@ -30,20 +34,16 @@ describe('Metalsmith Paths', function () {
   it('should use custom property', function (done) {
     plugin.should.be.a.Function
 
-    var files = {
-      'path/to/file.ext': {}
-    }
-
     plugin({
       property: 'foo'
     })(files, null, function () {
-      files['path/to/file.ext'].should.have.property('foo').and.be.an.Object
+      files[relativeFilePath].should.have.property('foo').and.be.an.Object
 
-      files['path/to/file.ext'].foo.should.have.property('base').and.equal('file.ext')
-      files['path/to/file.ext'].foo.should.have.property('dir').and.equal('path/to')
-      files['path/to/file.ext'].foo.should.have.property('ext').and.equal('.ext')
-      files['path/to/file.ext'].foo.should.have.property('name').and.equal('file')
-      files['path/to/file.ext'].foo.should.have.property('href').and.equal('/path/to/file.ext')
+      files[relativeFilePath].foo.should.have.property('base').and.equal('file.ext')
+      files[relativeFilePath].foo.should.have.property('dir').and.equal('path/to')
+      files[relativeFilePath].foo.should.have.property('ext').and.equal('.ext')
+      files[relativeFilePath].foo.should.have.property('name').and.equal('file')
+      files[relativeFilePath].foo.should.have.property('href').and.equal('/path/to/file.ext')
 
       done()
     })


### PR DESCRIPTION
This PR fixes the current issue where, on Windows, the dir and href properties contain backslashes.  Obviously a URL should only use forward slashes.
